### PR TITLE
Package Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,15 @@
 				"extensions": [
 					".xaml"
 				]
+			},
+			{
+				"id": "csharp",
+				"aliases": [
+					"C#"
+				],
+				"extensions": [
+					".cs"
+				]
 			}
 		],
 		"grammars": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"typescript": "^4.2.2",
 		"vsce": "^1.85.0",
 		"vscode-debugadapter-testsupport": "^1.45.0",
-		"vscode-nls-dev": "^3.3.2",
+		"vscode-nls-dev": "^4.0.0",
 		"webpack": "^5.24.2",
 		"webpack-cli": "^4.5.0"
 	},

--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
 				"type": "comet",
 				"label": ".NET Comet (Mobile)",
 				"program": "./src/mobile-debug/bin/Debug/net6.0/mobile-debug.dll",
-				"runtime" : "dotnet",
+				"runtime": "dotnet",
+				"languages": ["csharp"],
 				"initialConfigurations": [
 					{
 						"name": "%comet.launch.config.name%",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,19 @@
 							}
 						}
 					}
-				}
+				},
+				"configurationSnippets": [
+					{
+						"label": ".NET Mobile (Comet): Debug Configuration",
+						"description": "A new configuration for building and debugging a .NET Mobile (Comet) app.",
+						"body": {
+							"name": "%comet.launch.config.name%",
+							"type": "comet",
+							"request": "launch",
+							"preLaunchTask": "comet: Build"
+						}
+					}
+				]
 			}
 		]
 	}

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
 						"name": "%comet.launch.config.name%",
 						"type": "comet",
 						"request": "launch",
-						"preLaunchTask": "comet: Run"
+						"preLaunchTask": "comet: Build"
 					}
 				],
 				"configurationAttributes": {

--- a/src/mobile-debug/MonoDebugSession.cs
+++ b/src/mobile-debug/MonoDebugSession.cs
@@ -495,11 +495,20 @@ namespace VSCodeDebug
 
 				booted = emuProc.WaitForBootComplete();
 			}
-
+			
 			if (!booted)
 			{
-				SendConsoleEvent($"Failed to launch or wait for emulator... {options.AdbDeviceName}");
-				return (false, $"Launching Android Emulator {options.AdbDeviceName} failed.");
+				// We don't know if it's a device or emulator, and we obviously don't need to boot a device
+				// But we want to make sure ADB sees whatever the target is
+				var adb = new AndroidSdk.Adb();
+				var adbDevice = adb.GetDevices()?.FirstOrDefault(d => d.Serial.Equals(options.DeviceId, StringComparison.InvariantCultureIgnoreCase));
+
+				// If it's an emulator we want to make sure it was booted
+                if (adbDevice == null || adbDevice.IsEmulator)
+                {
+					SendConsoleEvent($"Failed to launch or wait for emulator or device... {options.AdbDeviceName}");
+					return (false, $"Launching Android Emulator {options.AdbDeviceName} failed.");
+				}
 			}
 
 			SendConsoleEvent($"Emulator ready! ({options.AdbDeviceName})");

--- a/src/typescript/build-task.ts
+++ b/src/typescript/build-task.ts
@@ -176,8 +176,10 @@ export class MobileBuildTaskProvider implements vscode.TaskProvider {
 		if (this.platform && !isCore)
 			platformArg = `;Platform=${platform}`;
 
+		// Android can run right from the build, no need to do it in mobile-debug
 		var msbuildTarget = 'Run';
 
+		// The mobile-debug will use mlaunch to run rather than suggesting it here
 		if (projectType == ProjectType.iOS || projectType == ProjectType.MacCatalyst)
 			msbuildTarget = 'Build';
 		


### PR DESCRIPTION
- Get suggested as the launch.json provider in more places
- Bring back (and fix) C# association
- Fix generated launch.json's preLaunchTask
- Don't fail on trying to start android devices thinking it's an emulator