### PR TITLE
Trim key and value from ini

### DIFF
--- a/src/mobile-debug/UtilRunner.cs
+++ b/src/mobile-debug/UtilRunner.cs
@@ -220,7 +220,7 @@ namespace VsCodeMobileUtil
 
 				if ((parts?.Length ?? 0) == 2)
 				{
-					r[parts[0]] = parts[1];
+					r[parts[0].Trim()] = parts[1].Trim();
 				}
 			}
 


### PR DESCRIPTION
There may be blank spaces around `=` in ini entries, so trim them before setting key and value.
Otherwise an runtime exception may be thrown while getting android devices.