### PR TITLE
Remove unused config reference

### DIFF
--- a/src/mobile-debug/UtilRunner.cs
+++ b/src/mobile-debug/UtilRunner.cs
@@ -120,11 +120,9 @@ namespace VsCodeMobileUtil
 			{
 				var avdConfig = ParseAvdConfigIni(Path.Combine(a.Path, "config.ini"));
 
-				var abi = avdConfig?["abi.type"] ?? string.Empty;
 				var architecture = avdConfig?["hw.cpu.arch"] ?? string.Empty;
 				var manufacturer = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(avdConfig?["hw.device.manufacturer"] ?? string.Empty);
 				var model = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(avdConfig?["hw.device.name"] ?? string.Empty);
-				var tag = avdConfig?["tag.display"] ?? string.Empty;
 
 				// See if ADB returned a running instance
 				var emulator = emulators.FirstOrDefault(e => e.EmulatorName == a.Name);


### PR DESCRIPTION
Seems that not every avd config has a `tag.display` field in config, so I remove all unused to avoid exceptions.

Fixes #16