### PR TITLE
Improve iOS devices order

### DIFF
--- a/src/mobile-debug/XCode.cs
+++ b/src/mobile-debug/XCode.cs
@@ -44,7 +44,9 @@ namespace VsCodeMobileUtil
 					Platforms = d.DotNetPlatforms,
 					Serial = d.Identifier,
 					Version = d.OperatingSystemVersion
-				});
+				})
+				.OrderBy(d => d.IsEmulator)
+				.ThenBy(d => d.Name);;
 
 			return filteredDevices.ToList();
 		}


### PR DESCRIPTION
Order the iOS devices with device first, then emulator by name. Currently it looks random.