### PR TITLE
Return mobile-debug error correctly

### DIFF
--- a/src/typescript/util.ts
+++ b/src/typescript/util.ts
@@ -67,7 +67,11 @@ export class MobileUtil
 
 		var txt = proc['stdout'];
 
-		return JSON.parse(txt) as CommandResponse<TResult>;
+		var result = JSON.parse(txt) as CommandResponse<TResult>;
+		if (result.error) {
+			throw new Error(result.error);
+		}		
+		return result;
 	}
 
 	public async Debug(jsonConfig: string): Promise<SimpleResult>


### PR DESCRIPTION
Return mobile-debug error such as "Could not find adb" instead of "Cannot read properties of undefined (reading 'map')" which is unhelpful like when android sdk is missing https://github.com/Clancey/vscode-comet/issues/22