### PR TITLE
fix extension cannot select devices issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "node": "^6.3.0"
   },
   "dependencies": {
-    "@types/execa": "^2.0.0",
     "@types/vscode": "^1.72.0",
     "execa": "^6.1.0",
     "rxjs": "^7.5.7",

--- a/src/mobile-debug/Program.cs
+++ b/src/mobile-debug/Program.cs
@@ -9,13 +9,11 @@ using System.Net;
 using System.Net.Sockets;
 using VSCodeDebug.Debugger;
 using VsCodeMobileUtil;
-
+using Esp.Resources;
 namespace VSCodeDebug;
 
 internal class Program
 {
-	const int DEFAULT_PORT = 4711;
-
 	private static bool trace_requests;
 	private static bool trace_responses;
 	static string LOG_FILE_PATH = null;
@@ -41,12 +39,12 @@ internal class Program
 				trace_responses = true;
 				break;
 			case "--server":
-				port = DEFAULT_PORT;
+				port = Constants.DEFAULT_PORT;
 				break;
 			default:
 				if (a.StartsWith("--server=")) {
 					if (!int.TryParse(a.Substring("--server=".Length), out port)) {
-						port = DEFAULT_PORT;
+						port = Constants.DEFAULT_PORT;
 					}
 				}
 				else if( a.StartsWith("--log-file=")) {

--- a/src/mobile-debug/mobile-debug.csproj
+++ b/src/mobile-debug/mobile-debug.csproj
@@ -11,6 +11,7 @@
 		<ProjectReference Include="..\..\external\debugger-libs\Mono.Debugger.Soft\Mono.Debugger.Soft.csproj" />
 		<ProjectReference Include="..\..\external\debugger-libs\Mono.Debugging\Mono.Debugging.csproj" />
 		<ProjectReference Include="..\..\external\debugger-libs\Mono.Debugging.Soft\Mono.Debugging.Soft.csproj" />
+		<ProjectReference Include= "..\..\external\Reloadify3000\Esp.Resources\Esp.Resources.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/typescript/util.ts
+++ b/src/typescript/util.ts
@@ -57,10 +57,7 @@ export class MobileUtil
 
 		var proc: any;
 
-		//if (this.isUnix)
-			proc = await execa('dotnet', [ this.UtilPath ].concat(stdargs));
-		// else
-		// 	proc = await execa(this.UtilPath, stdargs);
+		proc = await execa.execa('dotnet', [ this.UtilPath ].concat(stdargs));
 
 		var txt = proc['stdout'];
 


### PR DESCRIPTION
As execa already contain the typescript interface, so we don't need to reference @type/execa