### PR TITLE
Fix project cannot load

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -15,11 +15,12 @@ function Vsix
 }
 function BuildNet
 {
-	Write-Host "Building .NET Project..."
+	Write-Host "Building .NET Projects..."
 
 	& dotnet build /r /p:Configuration=Debug ./src/mobile-debug/mobile-debug.csproj
+	& dotnet build /r /p:Configuration=Debug ./src/DotNetWorkspaceAnalyzer/DotNetWorkspaceAnalyzer.csproj
 
-	Write-Host "Done .NET Project."
+	Write-Host "Done .NET Projects."
 
 	Write-Host "Building Reloadify 3000 "
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "node": "^6.3.0"
   },
   "dependencies": {
-    "@types/execa": "^2.0.0",
     "@types/vscode": "^1.72.0",
     "execa": "^6.1.0",
     "rxjs": "^7.5.7",

--- a/src/DotNetWorkspaceAnalyzer/WorkspaceAnalyzer.cs
+++ b/src/DotNetWorkspaceAnalyzer/WorkspaceAnalyzer.cs
@@ -46,10 +46,10 @@ public partial class WorkspaceAnalyzer : IWorkspaceAnalyzerService
 		CurrentWorkspace.WorkspaceChanged += CurrentWorkspace_WorkspaceChanged;
 		CurrentWorkspace.WorkspaceFailed += CurrentWorkspace_WorkspaceFailed;
 
-        if (path.EndsWith(".sln"))
-            await CurrentWorkspace.OpenSolutionAsync(path);
-        else if (path.EndsWith(".csproj"))
-            await CurrentWorkspace.OpenProjectAsync(path);
+		if (path.EndsWith(".sln"))
+			await CurrentWorkspace.OpenSolutionAsync(path);
+		else if (path.EndsWith(".csproj"))
+			await CurrentWorkspace.OpenProjectAsync(path);
 	}
 
 	private void CurrentWorkspace_WorkspaceFailed(object? sender, Microsoft.CodeAnalysis.WorkspaceDiagnosticEventArgs e)

--- a/src/DotNetWorkspaceAnalyzer/WorkspaceAnalyzer.cs
+++ b/src/DotNetWorkspaceAnalyzer/WorkspaceAnalyzer.cs
@@ -46,8 +46,10 @@ public partial class WorkspaceAnalyzer : IWorkspaceAnalyzerService
 		CurrentWorkspace.WorkspaceChanged += CurrentWorkspace_WorkspaceChanged;
 		CurrentWorkspace.WorkspaceFailed += CurrentWorkspace_WorkspaceFailed;
 
-		
-		await CurrentWorkspace.OpenSolutionAsync(path);
+        if (path.EndsWith(".sln"))
+            await CurrentWorkspace.OpenSolutionAsync(path);
+        else if (path.EndsWith(".csproj"))
+            await CurrentWorkspace.OpenProjectAsync(path);
 	}
 
 	private void CurrentWorkspace_WorkspaceFailed(object? sender, Microsoft.CodeAnalysis.WorkspaceDiagnosticEventArgs e)

--- a/src/typescript/extensionInfo.ts
+++ b/src/typescript/extensionInfo.ts
@@ -9,5 +9,5 @@ export const outputChanelName = "Comet for .NET Mobile";
 export const extensionPath = vscode.extensions.getExtension(extensionId).extensionPath;
 export const configureExtensionCommand = "extension.comet.configureExceptions";
 export const startSessionCommand = "extension.comet.startSession";
-export const analyzerExePath = path.join(extensionPath, 'src', 'DotNetWorkspaceAnalyzer', 'bin', 'Debug', 'net6.0', 'DotNetWorkspaceAnalyzer');
+export const analyzerExePath = path.join(extensionPath, 'src', 'DotNetWorkspaceAnalyzer', 'bin', 'Debug', 'net6.0', 'DotNetWorkspaceAnalyzer.dll');
 export const mobileDebugPath = path.join(extensionPath, 'src', 'mobile-debug', 'bin', 'Debug', 'net6.0', 'mobile-debug.dll');

--- a/src/typescript/project-manager.ts
+++ b/src/typescript/project-manager.ts
@@ -57,7 +57,7 @@ export class MobileProjectManager {
 
 		var loadingStatusBarItemHidden = false;
 
-		let childProcess = cp.spawn(analyzerExePath);
+		let childProcess = cp.spawn('dotnet', [ analyzerExePath ]);
 
 		// Use stdin and stdout for communication:
 		this.dotnetProjectAnalyzerRpc = rpc.createMessageConnection(

--- a/src/typescript/util.ts
+++ b/src/typescript/util.ts
@@ -57,10 +57,7 @@ export class MobileUtil
 
 		var proc: any;
 
-		//if (this.isUnix)
-			proc = await execa('dotnet', [ this.UtilPath ].concat(stdargs));
-		// else
-		// 	proc = await execa(this.UtilPath, stdargs);
+		proc = await execa.execa('dotnet', [ this.UtilPath ].concat(stdargs));
 
 		var txt = proc['stdout'];
 


### PR DESCRIPTION
Fix the project name cannot display issue.

Fix if there's no solution file in the current workspace, the extension still can load the project.