### PR TITLE
Handle `AvdManager.ListAvds` crash

### DIFF
--- a/src/mobile-debug/UtilRunner.cs
+++ b/src/mobile-debug/UtilRunner.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Options;
+using Mono.Options;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -113,7 +113,22 @@ class UtilRunner
 
 		// Get all Avds
 		var avdManager = new AndroidSdk.AvdManager();
-		var avds = avdManager.ListAvds() ?? Enumerable.Empty<AndroidSdk.AvdManager.Avd>();
+		var avds = Enumerable.Empty<AndroidSdk.AvdManager.Avd>();
+		try
+		{
+			avds = avdManager.ListAvds() ?? Enumerable.Empty<AndroidSdk.AvdManager.Avd>();
+		}
+		catch (NullReferenceException ex)
+		{
+			if (results.Any())
+			{
+				Console.Error.WriteLine($"AVD Manager crashed trying to list emulators.\nListing only {results.Count} physical devices.");
+			}
+			else
+			{
+				throw new NullReferenceException("AVD Manager crashed trying to list emulators.\nAborting as no physical devices were found.", ex);
+			}
+		}
 
 		// Look through all avd's to list, but let's be smart and see if any of them
 		// are already running (so were listed in the adb devices output)

--- a/src/typescript/util.ts
+++ b/src/typescript/util.ts
@@ -56,16 +56,14 @@ export class MobileUtil
 				stdargs.push(args[a]);
 		}
 
-		var proc: any;
+		const { stdout, stderr } = await execa('dotnet', [ this.UtilPath ].concat(stdargs));
 
-		proc = await execa('dotnet', [ this.UtilPath ].concat(stdargs));
-
-		var txt = proc['stdout'];
-
-		var result = JSON.parse(txt) as CommandResponse<TResult>;
+		var result = JSON.parse(stdout) as CommandResponse<TResult>;
 		if (result.error) {
 			throw new Error(result.error);
-		}		
+		} else if (stderr) {
+			vscode.window.showErrorMessage(stderr);
+		}
 		return result;
 	}
 


### PR DESCRIPTION
Workaround for #22  in my case. For unknown reasons `AvdManager.ListAvds()` crashes with a `NullReferenceException`. It seems that the error is not in this repo.

If the error occurs, rethrow with a more specific error if there are no results. If there are some results (physical devices) then only _write to stderr_.

On the node side, the `RunCommand` has been updated to pop a vscode error window if the `stderr` of `execa` is non-falsy. (This might theoretically cause such pop-ups for other commands, too.)

The solution is far from perfect, as the current code base cannot model a non-fatal error. Thus I've decided to use `stderr` which provides a functioning and well understood mechanism.

Someone with a better idea of the code base should have a look at this. The application can probably be remodelled to support non-fatal error reporting.

Personally I'd love to have this merged first, as it solves a blocking issue for me, however, I can instead keep using my own build.