### PR TITLE
Fix hot reload not working

### DIFF
--- a/src/mobile-debug/Debugger/MonoDebugSession.cs
+++ b/src/mobile-debug/Debugger/MonoDebugSession.cs
@@ -62,6 +62,7 @@ public class MonoDebugSession : DebugSession
 		_frameHandles = new Handles<Mono.Debugging.Client.StackFrame>();
 		_seenThreads = new Dictionary<int, Thread>();
 		HotReloadManager ??= new HotReloadManager();
+		HotReloadManager.OutputHandler = SendConsoleEvent;
 		_debuggerSessionOptions = new DebuggerSessionOptions
 		{
 			EvaluationOptions = EvaluationOptions.DefaultOptions

--- a/src/mobile-debug/HotReload/HotReloadManager.cs
+++ b/src/mobile-debug/HotReload/HotReloadManager.cs
@@ -37,11 +37,10 @@ namespace VSCodeDebug.HotReload
 
 			args.AppendQuoted(launchData.Project);
 			args.Append($"-t={launchData.ProjectTargetFramework}");
-			args.Append($"-p={launchData.Platform}");
 			args.Append($"-c={launchData.Configuration}");
 			args.Append($"-f=\"{launchData.WorkspaceDirectory}\"");
 			var runCommand = args.ToString();
- 			runner = new DotnetRunner(runCommand, projectDir, CancellationToken.None, s => Console.WriteLine(s));
+ 			runner = new DotnetRunner(runCommand, projectDir, CancellationToken.None, OutputHandler);
 		}
 
 		public void Start(SoftDebuggerSession debugger)
@@ -69,5 +68,7 @@ namespace VSCodeDebug.HotReload
 			}
 			runner = null;
 		}
+
+		public Action<string> OutputHandler {get;set;}
 	}
 }


### PR DESCRIPTION
As dotnet build we didn't pass the platform as argument, but we pass it to Reloadify, this cause the Reloadify cannot find the output file path, as it missing the platform.

The stdout from Reloadify cannot print to VS debug console. I send them to debug console